### PR TITLE
fix: don't crash on first-ever journal when prevJournals is empty

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -151,6 +151,9 @@ async function updateNewJournalWithAllTODOs({blocks, txData, txMeta}) {
 
   const prevJournals = await queryCurrentRepoRangeJournals(newJournalBlock['journalDay']);
   console.log({prevJournals});
+  if (!prevJournals || prevJournals.length === 0) {
+    return;
+  }
   const latestJournal = prevJournals.reduce( // TODO: This aggregation should be handled by the query itself.
     (prev, current) => prev['journal-day'] > current['journal-day'] ? prev : current
   );


### PR DESCRIPTION
## Summary
- `updateNewJournalWithAllTODOs` calls `prevJournals.reduce(...)` without an initial value; if `prevJournals` is `[]` (fresh graph, or any path where today is the first journal in datascript), `reduce` throws and the error is silently swallowed inside the async listener.
- Returns early when there are no prior journals — nothing to migrate.

## Why now
Surfaced by a headless end-to-end test that drove Logseq via Playwright. On cold-load Logseq parses journals serially, so the migration listener can fire once *before* yesterday's journal lands in datascript — exactly the empty-array case.

## Test plan
- [x] Headless E2E run (Flow A: pre-seed yesterday + today, delete today, let Logseq's fs-watcher trigger `create-today-journal!`) passes end-to-end with this fix in place; without it, the listener throws on cold-load before the real migration ever runs.
- [ ] Manual verification in your real Logseq install once the PR lands (delete today's journal in a graph that has no prior journals — should no-op cleanly instead of erroring in DevTools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)