### PR TITLE
fix: keep DONE children in source under their parent

### DIFF
--- a/e2e/cases/migration.mjs
+++ b/e2e/cases/migration.mjs
@@ -137,10 +137,6 @@ export const migrationCases = [
 
   {
     name: 'rule-7-recursion-mixed-children',
-    // KNOWN BUG: when a parent has mixed children, the DONE child is
-    // currently dropped instead of staying in source. The test asserts
-    // the *correct* behavior — fix the plugin to make this pass.
-    knownFailing: true,
     journals: {
       yesterday: `- TODO Parent task
 \t- TODO Subtask 1

--- a/src/main.ts
+++ b/src/main.ts
@@ -205,7 +205,11 @@ async function recursiveCopyBlocks(srcBlock: BlockEntity, lastDestBlock: BlockEn
   // copied from https://github.com/vipzhicheng/logseq-plugin-move-block TODO add note in readme
   let hasAnyDoneDescendant = false;
   if (doneRegex.test(srcBlock.content)) {
-    return [lastDestBlock, true];
+    // DONE blocks stay in source. Signal hasAnyDoneDescendant=true so the
+    // caller (parent block) knows it has a DONE descendant and must NOT
+    // delete itself from source — otherwise this DONE child would be
+    // removed along with the parent's subtree.
+    return [lastDestBlock, false, true];
   }
   let newBlock = lastDestBlock;
   if (lastDestBlock.content !== '') {


### PR DESCRIPTION
## Summary
- When a TODO parent has mixed TODO/DONE children, the DONE child was being dropped from source along with the parent. The DONE early-return in `recursiveCopyBlocks` was returning a 2-element array, leaving `hasAnyDoneDescendant` as `undefined` in the caller — so the parent thought it had no DONE descendants and removed itself from source, orphaning the DONE.
- 4-line fix: return `[lastDestBlock, false, true]` from the early return — `isBlockRemoved=false` (DONE was not removed) and `hasAnyDoneDescendant=true` (signal to the parent: stay in source).

## Effect on the E2E suite
- `rule-7-recursion-mixed-children` now PASSes — was the last KNOWN-FAIL in the suite.
- **19/19 PASS, 0 FAIL, 0 KNOWN-FAIL** — the suite is fully green for the first time.

## Test plan
- [x] `pnpm test:e2e` runs green (19/19 PASS).
- [x] No real `~/.logseq/` writes (verified by mtime snapshot).
- [x] Tiny diff: 4 lines in `src/main.ts`, drop the `knownFailing: true` flag from rule-7's case definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)