### PR TITLE
ci: tag-as-truth release workflow + modern actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,57 +9,99 @@ on:
 env:
   PLUGIN_NAME: logseq-plugin-daily-todo
 
+permissions:
+  contents: write   # Needed to push the package.json version bump back to master
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          # Full history so we can commit the version bump back to master.
+          fetch-depth: 0
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
-      - name: Build
-        id: build
+
+      - name: Enable corepack (pnpm)
+        run: corepack enable
+
+      - name: Sync package.json version with tag
+        id: version_sync
         run: |
-          npm install -g pnpm
-          pnpm install
-          pnpm build
-          mv dist ${{ env.PLUGIN_NAME }}
-          zip -r ${{ env.PLUGIN_NAME }}.zip ${{ env.PLUGIN_NAME }}
-          tar -cvzf ${{ env.PLUGIN_NAME }}.tar.gz -C ${{ env.PLUGIN_NAME }} .
-          ls
-          echo "::set-output name=tag_name::$(git tag --sort version:refname | tail -n 1)"
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "tag_version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
+          echo "pkg_version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$PKG_VERSION" = "$TAG_VERSION" ]; then
+            echo "package.json already matches tag ($TAG_VERSION); no bump needed"
+            echo "needs_commit=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "rewriting package.json version: $PKG_VERSION -> $TAG_VERSION"
+            node -e "
+              const fs = require('fs');
+              const p = require('./package.json');
+              p.version = '$TAG_VERSION';
+              fs.writeFileSync('./package.json', JSON.stringify(p, null, 2) + '\n');
+            "
+            echo "needs_commit=true" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Create Release
-        uses: ncipollo/release-action@v1
-        id: create_release
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        # Build uses the rewritten package.json above so dist/package.json carries
+        # the tag's version. Run BEFORE we switch branches to commit the bump back.
+        run: pnpm build
+
+      - name: Package dist
+        run: |
+          set -euo pipefail
+          mv dist "${PLUGIN_NAME}"
+          zip -r "${PLUGIN_NAME}.zip" "${PLUGIN_NAME}"
+          tar -cvzf "${PLUGIN_NAME}.tar.gz" -C "${PLUGIN_NAME}" .
+
+      - name: Create release with assets
+        uses: softprops/action-gh-release@v3
+        with:
+          # softprops infers tag name from GITHUB_REF on tag pushes.
+          files: |
+            ${{ env.PLUGIN_NAME }}.zip
+            ${{ env.PLUGIN_NAME }}.tar.gz
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ github.ref }}
-        with:
-          allowUpdates: true
-          draft: false
-          prerelease: false
 
-      - name: Upload zip file
-        id: upload_zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ env.PLUGIN_NAME }}.zip
-          asset_name: ${{ env.PLUGIN_NAME }}-${{ steps.build.outputs.tag_name }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload tar.gz file
-        id: upload_metadata
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ env.PLUGIN_NAME }}.tar.gz
-          asset_name: ${{ env.PLUGIN_NAME }}-${{ steps.build.outputs.tag_name }}.tar.gz
-          asset_content_type: application/gzip
+      - name: Commit version bump back to master
+        if: steps.version_sync.outputs.needs_commit == 'true'
+        # Runs LAST so a failed build/release doesn't leave master with a
+        # version bump for an artifact that was never published.
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin master
+          git checkout master
+          # Re-apply the bump on master in case master moved during the workflow
+          TAG_VERSION="${{ steps.version_sync.outputs.tag_version }}"
+          node -e "
+            const fs = require('fs');
+            const p = require('./package.json');
+            if (p.version !== '$TAG_VERSION') {
+              p.version = '$TAG_VERSION';
+              fs.writeFileSync('./package.json', JSON.stringify(p, null, 2) + '\n');
+            }
+          "
+          if git diff --quiet package.json; then
+            echo "package.json on master already matches tag; nothing to commit"
+          else
+            git add package.json
+            git commit -m "chore: bump version to ${TAG_VERSION} [skip ci]"
+            git push origin master
+          fi

--- a/agents/build-and-release.md
+++ b/agents/build-and-release.md
@@ -41,38 +41,52 @@ source on every `pnpm build`, so this isn't sticky.
 ## Publishing a new version
 
 The release flow is automated via
-[`.github/workflows/publish.yml`](../.github/workflows/publish.yml). It
-fires on **any tag push** matching `*` and:
+[`.github/workflows/publish.yml`](../.github/workflows/publish.yml).
+**The pushed tag is the source of truth for the version.** The workflow:
 
-1. Runs `pnpm install && pnpm build`
-2. Renames `dist/` to `logseq-plugin-daily-todo/`
-3. Zips and tars it
-4. Creates a GitHub release attached to the pushed tag
-5. Uploads the zip and tar.gz as release assets
+1. Reads the tag (e.g. `0.0.9`) and rewrites `package.json` to match.
+2. Runs `pnpm install --frozen-lockfile && pnpm build` so
+   `dist/package.json` carries the tag's version.
+3. Packages `dist/` as zip + tar.gz.
+4. Creates a GitHub release attached to the tag with both archives
+   uploaded via `softprops/action-gh-release`.
+5. **Commits the `package.json` version bump back to `master`** with
+   `[skip ci]` so the source tracks the released version. Runs last,
+   after a successful release, so a failed build doesn't leave master
+   with a phantom bump.
 
-The Logseq Marketplace registry watches for new releases and indexes them.
+The Logseq Marketplace registry watches for new releases and indexes
+them within an hour or so.
 
-### Version bump checklist
+### Cutting a release
 
-1. Edit `package.json` → bump `&quot;version&quot;`. Always bump it. Skipping this
-   step is how 0.0.7 ended up with a tag but a `package.json` that still
-   said `&quot;0.0.6&quot;` — the Marketplace card and the unpacked card showed
-   different versions for over a year.
-2. Run `pnpm build` and confirm `dist/package.json` has the new version.
-3. Optionally smoke-test in Logseq with the unpacked build.
-4. Commit and push to master.
-5. `git tag <version>` (no `v` prefix — match the existing pattern) and
-   `git push origin <version>`. Pushing the tag fires the workflow.
-6. Watch the Action complete on GitHub. Confirm the release exists with
-   the zip and tar.gz attached.
-7. Marketplace pickup is asynchronous — usually within an hour.
+1. Make sure master is in the state you want to release.
+2. `git tag <version>` (no `v` prefix — match the existing pattern,
+   e.g. `0.0.9`).
+3. `git push origin <version>`.
+4. Watch the Action on GitHub. On success: the release page has the
+   zip and tar.gz, and master gains a `chore: bump version to X.Y.Z`
+   commit from `github-actions[bot]`.
+
+That's it. **You do not bump `package.json` manually.** The workflow
+makes the tag and `package.json` agree by construction, so the
+0.0.7-style drift (tag was 0.0.7, `package.json` said 0.0.6 for over
+a year) cannot recur.
 
 ### Don't
 
-- **Don't push a tag without bumping `package.json`** (see 0.0.7 incident).
-- **Don't amend or force-push tags** that have already been published as
-  releases. Cut a new patch version instead.
+- **Don't manually edit `package.json`'s `version` field.** Let the
+  workflow handle it; otherwise master and the next tag may diverge.
+- **Don't amend or force-push tags** that have already been published
+  as releases. Cut a new patch version instead.
 - **Don't commit `dist/`.** It's gitignored and rebuilt by CI from the
   tag.
-- **Don't skip the workflow with `[skip ci]`** on a tag push — the
-  workflow *is* the release.
+
+### When master and the tag would have raced
+
+The workflow handles the (rare) case where master moves between when
+the action checks out the tag and when it tries to commit the bump
+back: it does `git fetch origin master && git checkout master` before
+the bump-and-push and re-applies the version edit. If master was bumped
+to the same version by another action concurrently, the diff is empty
+and no commit is created. Worst case is a benign no-op.

--- a/agents/gotchas.md
+++ b/agents/gotchas.md
@@ -72,17 +72,22 @@ which means it changes every time you load unpacked, which is fine. The
 plugin's stable identity in the Marketplace comes from the GitHub repo
 slug, not from this id.
 
-## Versions can drift between tag and `package.json`
+## Don't manually bump `package.json`'s version
 
-The publish workflow fires on tag push and bundles `dist/package.json`
-into the release. But `package.json`'s `&quot;version&quot;` is independent from
-the tag name — the workflow doesn't enforce that they match. We've seen
-a real instance where tag `0.0.7` was pushed but `package.json` still
-said `&quot;0.0.6&quot;`, and the Marketplace card showed `0.0.7` while the
-unpacked card showed `0.0.6` for over a year.
+The publish workflow rewrites `package.json` to match the pushed tag,
+builds against that, and commits the bump back to master with
+`[skip ci]`. **Don't edit the version field by hand** — it'll either
+get clobbered by the workflow or, worse, drift in ways the workflow
+can't reconcile.
 
-**Always bump `package.json` *before* tagging.** See
-[`build-and-release.md`](./build-and-release.md) for the checklist.
+To cut a release: `git tag <version>` and push. The workflow handles
+the rest. Full flow in [`build-and-release.md`](./build-and-release.md).
+
+This setup exists because the previous flow (manual bump before tag)
+had real drift: tag `0.0.7` was once pushed while `package.json`
+still said `&quot;0.0.6&quot;`, leaving the Marketplace card at 0.0.7 and the
+unpacked-plugin card at 0.0.6 for over a year. Tag-as-truth makes
+that class of bug impossible.
 
 ## `manualChunks` is not your friend here
 


### PR DESCRIPTION
## Summary
Modernizes `.github/workflows/publish.yml` to current standards and makes the **pushed tag the source of truth for the version**, eliminating the manual `package.json` bump step that drifted in the past (0.0.7 incident: tag was 0.0.7 but package.json said 0.0.6 for over a year).

## Workflow changes
- `actions/checkout@v4` (was `@v2`), with `fetch-depth: 0` so we can commit back to master.
- `softprops/action-gh-release@v3` — drops both `ncipollo/release-action` and the archived `actions/upload-release-asset`; one step now does release creation and asset upload.
- Replace deprecated `set-output` / direct `npm install -g pnpm` with `$GITHUB_OUTPUT` and `corepack enable`.
- `contents: write` permission for the version-bump push back to master.

## New release flow
1. On tag push (e.g. `0.0.9`), workflow rewrites `package.json`'s version to match the tag.
2. `pnpm install --frozen-lockfile && pnpm build` runs against the rewritten file so `dist/package.json` carries the tag's version.
3. Release is created with `<plugin>.zip` and `<plugin>.tar.gz` attached.
4. **Only after a successful release**, the workflow checks out master, re-applies the version edit, and pushes back as a `chore: bump version to X.Y.Z [skip ci]` commit by `github-actions[bot]`. Running this last means a failed build/release won't leave master with a phantom version bump.

The bump step uses `git diff --quiet` to skip if master already matches (idempotent under retries / concurrent bumps).

## Author flow
```bash
git tag 0.0.9
git push origin 0.0.9
```
No more manual `package.json` edits.

## Test plan
- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] Step ordering verified: bump → install → build → package → release → commit-back.
- [x] `softprops/action-gh-release@v3` is the current major (verified via GitHub API).
- [ ] First real release will fully exercise the flow. Plan: tag `0.0.9` after this PR merges; the workflow should rewrite `package.json` from `0.0.8` to `0.0.9`, build, release, and commit back.
- [ ] Edge case to verify on first release: `commit_back_to_master` runs as `github-actions[bot]` and the bump appears on master with the `[skip ci]` marker so we don't loop.

## Notes
- This is purely workflow + docs. No `src/` changes. The E2E suite is unaffected.
- If the first real release misbehaves, the worst case is the release succeeds but the version-bump push fails (e.g. branch protection). Master would still have its old version; the artifact's version is correct because the rewrite happened before build. We can repair by manually pushing the bump.
- Updates `agents/build-and-release.md` to document the new flow and `agents/gotchas.md` to retire the "manually bump before tagging" advice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)