### PR TITLE
chore: add logseq.id and title to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "license": "MIT",
   "main": "index.html",
   "logseq": {
+    "id": "logseq-plugin-daily-todo",
+    "title": "Daily TODO",
     "icon": "./icon.png"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
The `logseq` block in `package.json` previously declared only `icon`. Modern `@logseq/libs` expects a stable `id` — without one, Logseq generates a random hash on unpacked install (e.g. `_eokoi0fs1`), making the unpacked and marketplace installs look different to the SDK.

Adds the canonical pair:
```json
"id": "logseq-plugin-daily-todo",
"title": "Daily TODO"
```

This matches the pattern used by `vipzhicheng/logseq-plugin-vim-shortcuts`, `haydenull/logseq-plugin-agenda`, and other actively-maintained plugins.

## Compatibility
- **Marketplace installs**: unaffected. The marketplace registry keys plugins by GitHub repo slug.
- **Existing unpacked installs**: pick up the declared id on next reload. Their auto-generated random id was already being rewritten by the build script on every `pnpm build`.
- **The plugin's runtime**: identical — `id` is metadata, not consumed by `src/main.ts`.

## Test plan
- [x] `pnpm build` succeeds.
- [x] `dist/package.json` `logseq` block shows the expected id+title+icon.
- [ ] Smoke-test in Logseq with the new unpacked dist (plugin card shows the declared title; no random id generated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)