### PR TITLE
feat: add Vitest unit tests, headless perf gate, pnpm verify umbrella

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: E2E
+name: CI
 
 on:
   pull_request:
@@ -8,16 +8,13 @@ on:
 
 # Cancel duplicate runs on the same PR / branch
 concurrency:
-  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  e2e:
-    # macOS runner: lets the existing e2e/run.sh work as-is. The harness
-    # patches /tmp/LogseqPatched.app to honor LOGSEQ_FAKE_HOME (the
-    # macOS-specific HOME-vs-getpwuid workaround). Public repos get
-    # free macOS minutes; this job runs ~5 minutes.
-    runs-on: macos-latest
+  unit:
+    # Vitest unit tests for the pure helpers in src/lib.ts.
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -29,8 +26,95 @@ jobs:
 
       - name: Install pnpm
         # Pin pnpm so CI doesn't drift to a major that requires a newer
-        # Node. Once the toolchain modernization (#30) lands, package.json
+        # Node. Once toolchain modernization (#30) lands, package.json
         # will gain a "packageManager" field and we can switch to corepack.
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Unit tests
+        run: pnpm test
+
+  sanity:
+    # Sanity build: confirms the bundle still emits and the single-chunk
+    # invariant holds at the file level. Cheaper than the perf gate.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build plugin
+        run: pnpm build
+
+  performance:
+    # Headless perf gate. Drives perf-test/host.html via Playwright and
+    # asserts the load-time invariants. Build is a prerequisite for the
+    # gate (perf runs against dist/), so it lives in this job too.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        # Needed by scripts/perf.mjs.
+        run: pnpm exec playwright install chromium
+
+      - name: Build plugin
+        run: pnpm build
+
+      - name: Perf gate
+        # Runs scripts/perf.mjs against the just-built dist. Asserts:
+        #   - resourceCount === 1 (the 0.0.8 single-chunk invariant)
+        #   - median load < 800ms
+        run: pnpm perf
+
+  e2e:
+    # Slow gate: drives real Logseq.app via Playwright (~5 min). macOS
+    # runner because the existing e2e/run.sh patches Logseq's electron.js
+    # to honor LOGSEQ_FAKE_HOME — a workaround for macOS's
+    # HOME-vs-getpwuid divergence. Linux Electron honors HOME so the
+    # patch isn't needed, but porting would also need AppImage extraction
+    # and xvfb. Public repos get free macOS minutes.
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
@@ -79,9 +163,9 @@ jobs:
           ls /Applications/Logseq.app/Contents/MacOS/Logseq
 
       - name: Install Playwright Chromium
-        # Needed by scripts/perf.mjs; the E2E suite uses Playwright's
-        # Electron driver against Logseq.app and doesn't need Chromium,
-        # but install it anyway so a future pnpm verify run works too.
+        # The E2E suite uses Playwright's Electron driver against
+        # Logseq.app and doesn't need Chromium directly, but install
+        # for parity with the verify job.
         run: pnpm exec playwright install chromium
 
       - name: Run E2E suite

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,29 +30,28 @@ No UI, no network, no React. All logic lives in `src/main.ts`. The
 
 ## How to verify a change
 
-While iterating, run the quick sanity test for fast feedback (~17s):
+The canonical agent gate (no Logseq needed, ~5s):
 
 ```bash
-pnpm test:e2e:quick
+pnpm verify          # test + build + perf
 ```
 
-Before opening a PR, run the full migration suite (~2min):
+Inner-loop iteration on pure logic:
 
 ```bash
-pnpm test:e2e
+pnpm test            # Vitest unit tests (<1s)
+pnpm test:watch      # auto-rerun on save
 ```
 
-Both drive real Logseq via Playwright and assert on the on-disk
-markdown content. macOS only; requires `/Applications/Logseq.app`.
+End-to-end against real Logseq (macOS only, requires
+`/Applications/Logseq.app`):
+
+```bash
+pnpm test:e2e:quick  # one mega-migration sanity case (~17s)
+pnpm test:e2e        # full E2E suite (~3m30s, before opening a PR)
+```
+
 Full details in [`agents/testing.md`](./agents/testing.md).
-
-`pnpm build` produces `dist/`. Load it unpacked into Logseq to spot-check
-behavior the test suite doesn't cover yet — see
-[`agents/build-and-release.md`](./agents/build-and-release.md).
-
-Load-time can be measured without Logseq using
-[`perf-test/host.html`](./perf-test/host.html) — see
-[`agents/perf-testing.md`](./agents/perf-testing.md).
 
 ## Constraints worth knowing up front
 

--- a/agents/testing.md
+++ b/agents/testing.md
@@ -1,18 +1,33 @@
 # Testing
 
-The plugin has a headless end-to-end test suite that drives real
-Logseq.app via Playwright with an isolated temp profile. It covers the
-journal-migration logic by seeding markdown fixtures, triggering
-`create-today-journal!` via file deletion, and asserting on the
-resulting markdown content (file diffs, not API call counts).
+Two layers:
+
+1. **Unit tests** (Vitest, `pnpm test`) — pure-logic helpers in
+   `src/lib.ts`. <1s per run; ideal inner loop while iterating on
+   regex / state-machine / group-split logic.
+2. **End-to-end tests** (`pnpm test:e2e`) — drive real Logseq.app via
+   Playwright with an isolated temp profile. Cover the journal-migration
+   logic by seeding markdown fixtures, triggering `create-today-journal!`
+   via file deletion, and asserting on the resulting markdown content.
+3. **Perf gate** (`pnpm perf`) — drives `perf-test/host.html` headlessly
+   and asserts the load-time invariants: 1 resource fetch (no chunk
+   splitting), median load < 800ms over loopback.
 
 ## Commands
 
 ```bash
+pnpm test                  # Vitest unit tests (<1s)
+pnpm test:watch            # Vitest in watch mode
+pnpm perf                  # Headless perf gate (~5s)
+pnpm verify                # test + build + perf — the umbrella gate
 pnpm test:e2e:quick        # one mega-migration sanity case (~17s)
-pnpm test:e2e              # full suite — migration + shortcuts (~3m30s)
+pnpm test:e2e              # full E2E suite — migration + shortcuts (~3m30s)
 pnpm test:e2e:shortcuts    # shortcut cases only (~1m30s)
 ```
+
+`pnpm verify` is the canonical "did I break it?" agent gate. It does NOT
+run `pnpm test:e2e` because that needs Logseq.app installed and is
+slower; run E2E separately before opening a PR.
 
 ### Dev loop
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   },
   "scripts": {
     "build": "vite build && cp README.md LICENSE icon.png package.json dist/",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "perf": "node scripts/perf.mjs",
+    "verify": "pnpm test && pnpm build && pnpm perf",
     "test:e2e": "bash e2e/run.sh",
     "test:e2e:quick": "bash e2e/run.sh --quick",
     "test:e2e:shortcuts": "bash e2e/run.sh --shortcuts"
@@ -21,7 +25,8 @@
     "eslint": "^8.23.0",
     "playwright": "^1.59.1",
     "typescript": "^4.8.3",
-    "vite": "^3.1.0"
+    "vite": "^3.1.0",
+    "vitest": "^3.0.0"
   },
   "dependencies": {
     "@logseq/libs": "0.0.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,14 +31,251 @@ devDependencies:
   vite:
     specifier: ^3.1.0
     version: 3.1.0
+  vitest:
+    specifier: ^3.0.0
+    version: 3.2.4(@types/node@18.7.16)
 
 packages:
+
+  /@esbuild/aix-ppc64@0.27.7:
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.27.7:
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.27.7:
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.27.7:
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.27.7:
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.27.7:
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.27.7:
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.27.7:
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.27.7:
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.27.7:
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.27.7:
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@esbuild/linux-loong64@0.15.7:
     resolution: {integrity: sha512-IKznSJOsVUuyt7cDzzSZyqBEcZe+7WlBqTVXiF1OXP/4Nm387ToaXZ0fyLwI1iBlI/bzpxVq411QE2/Bt2XWWw==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.27.7:
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.27.7:
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.27.7:
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.27.7:
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.27.7:
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.27.7:
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-arm64@0.27.7:
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.27.7:
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.27.7:
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.27.7:
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openharmony-arm64@0.27.7:
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.27.7:
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.27.7:
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.27.7:
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.27.7:
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
     requiresBuild: true
     dev: true
     optional: true
@@ -84,6 +321,10 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
+  /@jridgewell/sourcemap-codec@1.5.5:
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+    dev: true
+
   /@logseq/libs@0.0.9:
     resolution: {integrity: sha512-cNqjZxJ2+JB/C+BjtQhUMQV2/223cqpx3+WnFS9RFDUUAhNq0jvT8pukqeYyDaPu7vV1lJRWtn76/8f/ThYuYg==}
     dependencies:
@@ -118,6 +359,225 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
+    dev: true
+
+  /@rollup/rollup-android-arm-eabi@4.60.3:
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.60.3:
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.60.3:
+    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.60.3:
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-arm64@4.60.3:
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-x64@4.60.3:
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.60.3:
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf@4.60.3:
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.60.3:
+    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.60.3:
+    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-loong64-gnu@4.60.3:
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-loong64-musl@4.60.3:
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-ppc64-gnu@4.60.3:
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-ppc64-musl@4.60.3:
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.60.3:
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-musl@4.60.3:
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu@4.60.3:
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.60.3:
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.60.3:
+    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-openbsd-x64@4.60.3:
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-openharmony-arm64@4.60.3:
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.60.3:
+    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.60.3:
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-gnu@4.60.3:
+    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.60.3:
+    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@types/chai@5.2.3:
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+    dev: true
+
+  /@types/deep-eql@4.0.2:
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+    dev: true
+
+  /@types/estree@1.0.8:
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+    dev: true
+
+  /@types/estree@1.0.9:
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
     dev: true
 
   /@types/json-schema@7.0.9:
@@ -255,6 +715,69 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
+  /@vitest/expect@3.2.4:
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+    dev: true
+
+  /@vitest/mocker@3.2.4(vite@7.3.3):
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      vite: 7.3.3(@types/node@18.7.16)
+    dev: true
+
+  /@vitest/pretty-format@3.2.4:
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+    dependencies:
+      tinyrainbow: 2.0.0
+    dev: true
+
+  /@vitest/runner@3.2.4:
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+    dev: true
+
+  /@vitest/snapshot@3.2.4:
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+    dev: true
+
+  /@vitest/spy@3.2.4:
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+    dependencies:
+      tinyspy: 4.0.4
+    dev: true
+
+  /@vitest/utils@3.2.4:
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+    dev: true
+
   /acorn-jsx@5.3.2(acorn@8.8.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -299,6 +822,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+    dev: true
+
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -317,9 +845,25 @@ packages:
       fill-range: 7.0.1
     dev: true
 
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+    dev: true
+
+  /chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
     dev: true
 
   /chalk@4.1.2:
@@ -328,6 +872,11 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+    dev: true
+
+  /check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
     dev: true
 
   /color-convert@2.0.1:
@@ -381,6 +930,23 @@ packages:
     dependencies:
       ms: 2.1.2
 
+  /debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
+  /deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+    dev: true
+
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
@@ -409,6 +975,10 @@ packages:
       no-case: 3.0.4
       tslib: 2.3.1
     dev: false
+
+  /es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+    dev: true
 
   /esbuild-android-64@0.15.7:
     resolution: {integrity: sha512-p7rCvdsldhxQr3YHxptf1Jcd86dlhvc3EQmQJaZzzuAxefO9PvcI0GLOa5nCWem1AJ8iMRu9w0r5TG8pHmbi9w==}
@@ -619,6 +1189,40 @@ packages:
       esbuild-windows-arm64: 0.15.7
     dev: true
 
+  /esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+    dev: true
+
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -741,6 +1345,12 @@ packages:
     engines: {node: '>=4.0'}
     dev: true
 
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.9
+    dev: true
+
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -749,6 +1359,11 @@ packages:
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
     dev: false
+
+  /expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+    dev: true
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -776,6 +1391,18 @@ packages:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
     dependencies:
       reusify: 1.0.4
+    dev: true
+
+  /fdir@6.5.0(picomatch@4.0.4):
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.4
     dev: true
 
   /file-entry-cache@6.0.1:
@@ -818,6 +1445,14 @@ packages:
 
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -952,6 +1587,10 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
+  /js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+    dev: true
+
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -990,6 +1629,10 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
+  /loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+    dev: true
+
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
@@ -1001,6 +1644,12 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
+
+  /magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
     dev: true
 
   /merge2@1.4.1:
@@ -1024,6 +1673,16 @@ packages:
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  /ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: true
+
+  /nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
 
   /nanoid@3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
@@ -1112,13 +1771,31 @@ packages:
       util: 0.10.4
     dev: false
 
+  /pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    dev: true
+
+  /pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+    dev: true
+
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: true
+
+  /picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
     dev: true
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+    dev: true
+
+  /picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
     dev: true
 
   /playwright-core@1.59.1:
@@ -1144,6 +1821,15 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
+
+  /postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
     dev: true
 
   /prelude-ls@1.2.1:
@@ -1204,6 +1890,41 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /rollup@4.60.3:
+    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
+      '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
+      '@rollup/rollup-linux-arm64-gnu': 4.60.3
+      '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
+      '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
+      '@rollup/rollup-win32-x64-gnu': 4.60.3
+      '@rollup/rollup-win32-x64-msvc': 4.60.3
+      fsevents: 2.3.3
+    dev: true
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -1230,6 +1951,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -1247,6 +1972,19 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
+  /std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+    dev: true
+
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -1257,6 +1995,12 @@ packages:
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+    dev: true
+
+  /strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+    dependencies:
+      js-tokens: 9.0.1
     dev: true
 
   /supports-color@7.2.0:
@@ -1273,6 +2017,37 @@ packages:
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    dev: true
+
+  /tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    dev: true
+
+  /tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+    dev: true
+
+  /tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+    dev: true
+
+  /tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    dev: true
+
+  /tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
     dev: true
 
   /to-regex-range@5.0.1:
@@ -1330,6 +2105,31 @@ packages:
       inherits: 2.0.3
     dev: false
 
+  /vite-node@3.2.4(@types/node@18.7.16):
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.3(@types/node@18.7.16)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
   /vite@3.1.0:
     resolution: {integrity: sha512-YBg3dUicDpDWFCGttmvMbVyS9ydjntwEjwXRj2KBFwSB8SxmGcudo1yb8FW5+M/G86aS8x828ujnzUVdsLjs9g==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -1357,12 +2157,139 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /vite@7.3.3(@types/node@18.7.16):
+    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      '@types/node': 18.7.16
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitest@3.2.4(@types/node@18.7.16):
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 5.2.3
+      '@types/node': 18.7.16
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.3)
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.3(@types/node@18.7.16)
+      vite-node: 3.2.4(@types/node@18.7.16)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
+
+  /why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
     dev: true
 
   /word-wrap@1.2.3:

--- a/scripts/perf.mjs
+++ b/scripts/perf.mjs
@@ -1,0 +1,106 @@
+// Headless perf gate — drives perf-test/host.html via Playwright and
+// asserts on load-time invariants:
+//
+//   1. resourceCount === 1   — the 0.0.8 single-chunk invariant. Catches
+//      re-introduction of manualChunks automatically.
+//   2. median elapsed < THRESHOLD_MS — catches gross regressions
+//      (import-heavy refactors, polyfill bloat, etc.).
+//
+// Loopback HTTP makes absolute milliseconds meaningless against the
+// `lsp://` protocol handler Logseq uses, so the threshold is generous.
+// The structural assertion (resourceCount) is what really matters.
+
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+
+const PORT = 8765;
+const RUNS = 10;
+const THRESHOLD_MS = 800;
+
+function staticServer(rootDir, port) {
+  const types = {
+    '.html': 'text/html',
+    '.js': 'application/javascript',
+    '.mjs': 'application/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json',
+    '.png': 'image/png',
+  };
+  const server = http.createServer((req, res) => {
+    let urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+    if (urlPath.endsWith('/')) urlPath += 'index.html';
+    const filePath = path.join(rootDir, urlPath);
+    // Prevent path-traversal — must stay under rootDir
+    if (!filePath.startsWith(rootDir)) {
+      res.writeHead(403); res.end('Forbidden'); return;
+    }
+    fs.readFile(filePath, (err, data) => {
+      if (err) { res.writeHead(404); res.end('Not found: ' + urlPath); return; }
+      const ext = path.extname(filePath);
+      res.writeHead(200, { 'Content-Type': types[ext] || 'application/octet-stream' });
+      res.end(data);
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(port, '127.0.0.1', () => resolve(server));
+  });
+}
+
+async function main() {
+  if (!fs.existsSync(path.join(ROOT, 'dist/index.html'))) {
+    console.error('dist/index.html missing — run pnpm build first');
+    process.exit(2);
+  }
+
+  const server = await staticServer(ROOT, PORT);
+  console.log(`[perf] static server listening on :${PORT}`);
+
+  const browser = await chromium.launch({ headless: true });
+  let exitCode = 0;
+  try {
+    const page = await browser.newPage();
+    await page.goto(`http://localhost:${PORT}/perf-test/host.html`);
+    await page.waitForFunction(() => typeof window.runHarnessN === 'function', { timeout: 5000 });
+
+    const result = await page.evaluate(async ({ pluginUrl, runs }) => {
+      return await window.runHarnessN(pluginUrl, 'perf-gate', runs);
+    }, { pluginUrl: `http://localhost:${PORT}/dist/index.html`, runs: RUNS });
+
+    console.log('[perf] result:', JSON.stringify({
+      median: result.median,
+      min: result.min,
+      max: result.max,
+      runs: result.runs,
+      resourceCount: result.resourceCount,
+    }, null, 2));
+
+    if (result.resourceCount !== 1) {
+      console.error(`[perf] FAIL: expected 1 resource fetch, got ${result.resourceCount}.`);
+      console.error('[perf] resources:', JSON.stringify(result.resources0, null, 2));
+      console.error('[perf] If this is intentional, the manualChunks-no-friends gotcha may need updating.');
+      exitCode = 1;
+    } else {
+      console.log('[perf] OK: single-chunk invariant holds (1 resource fetch).');
+    }
+
+    if (result.median !== null && result.median > THRESHOLD_MS) {
+      console.error(`[perf] FAIL: median load ${result.median}ms exceeds threshold ${THRESHOLD_MS}ms.`);
+      exitCode = 1;
+    } else if (result.median !== null) {
+      console.log(`[perf] OK: median load ${result.median}ms (threshold ${THRESHOLD_MS}ms).`);
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+  process.exit(exitCode);
+}
+
+main().catch(e => { console.error('[perf] THREW:', e); process.exit(99); });

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import {
+  blockContent,
+  extractTodoState,
+  getNextTodoState,
+  isHighlighted,
+  recursivelyCheckForRegexInBlock,
+  splitBlocksIntoGroups,
+  todoRegex,
+  doneRegex,
+  todoDoneRegex,
+  highlightRegex,
+  isUnderlineRegex,
+  type MinimalBlock,
+} from './lib';
+
+const b = (content: string, children: MinimalBlock[] = []): MinimalBlock => ({
+  content,
+  children,
+});
+
+describe('regex constants', () => {
+  it('todoRegex matches TODO prefix only at start', () => {
+    expect(todoRegex.test('TODO buy milk')).toBe(true);
+    expect(todoRegex.test('  TODO buy milk')).toBe(false);
+    expect(todoRegex.test('done TODO inline')).toBe(false);
+    expect(todoRegex.test('DONE buy milk')).toBe(false);
+  });
+
+  it('doneRegex matches DONE prefix only at start', () => {
+    expect(doneRegex.test('DONE pay bills')).toBe(true);
+    expect(doneRegex.test('TODO pay bills')).toBe(false);
+    expect(doneRegex.test('Already DONE')).toBe(false);
+  });
+
+  it('todoDoneRegex matches either', () => {
+    expect(todoDoneRegex.test('TODO x')).toBe(true);
+    expect(todoDoneRegex.test('DONE x')).toBe(true);
+    expect(todoDoneRegex.test('plain x')).toBe(false);
+  });
+
+  it('isUnderlineRegex matches <ins>...</ins>', () => {
+    expect(isUnderlineRegex.test('<ins>Project A</ins>')).toBe(true);
+    expect(isUnderlineRegex.test('Plain title')).toBe(false);
+    expect(isUnderlineRegex.test('mixed <ins>Section</ins> rest')).toBe(true);
+  });
+
+  it('highlightRegex matches optional TODO/DONE prefix + ^^...^^', () => {
+    expect(highlightRegex.test('^^just text^^')).toBe(true);
+    expect(highlightRegex.test('TODO ^^a task^^')).toBe(true);
+    expect(highlightRegex.test('DONE ^^a task^^')).toBe(true);
+    expect(highlightRegex.test('plain text')).toBe(false);
+  });
+
+  it('highlightRegex captures todoState and stripped content', () => {
+    const m = highlightRegex.exec('TODO ^^a task^^');
+    expect(m?.[1]).toBe('TODO ');
+    expect(m?.[2]).toBe('a task');
+
+    const m2 = highlightRegex.exec('^^plain^^');
+    expect(m2?.[1]).toBe('');
+    expect(m2?.[2]).toBe('plain');
+  });
+});
+
+describe('getNextTodoState', () => {
+  it('cycles blank → TODO → DONE → blank', () => {
+    expect(getNextTodoState('')).toBe('TODO ');
+    expect(getNextTodoState('TODO')).toBe('DONE ');
+    expect(getNextTodoState('DONE')).toBe('');
+  });
+
+  it('returns empty string for unknown input (defensive)', () => {
+    expect(getNextTodoState('UNKNOWN')).toBe('');
+  });
+});
+
+describe('blockContent', () => {
+  it('reads .content when only .content is set', () => {
+    expect(blockContent({ content: 'plain' })).toBe('plain');
+  });
+
+  it('prefers .title over .content (modern SDK)', () => {
+    expect(blockContent({ content: 'old', title: 'new' })).toBe('new');
+  });
+
+  it('reads .title when only .title is set', () => {
+    expect(blockContent({ title: 'new only' })).toBe('new only');
+  });
+
+  it('returns empty string for null/undefined/empty', () => {
+    expect(blockContent(null)).toBe('');
+    expect(blockContent(undefined)).toBe('');
+    expect(blockContent({})).toBe('');
+    expect(blockContent({ content: '' })).toBe('');
+  });
+});
+
+describe('isHighlighted', () => {
+  it('returns true for ^^...^^ blocks', () => {
+    expect(isHighlighted(b('^^buy milk^^'))).toBe(true);
+    expect(isHighlighted(b('TODO ^^buy milk^^'))).toBe(true);
+    expect(isHighlighted(b('DONE ^^pay bills^^'))).toBe(true);
+  });
+
+  it('returns false for non-highlighted', () => {
+    expect(isHighlighted(b('TODO buy milk'))).toBe(false);
+    expect(isHighlighted(b('plain text'))).toBe(false);
+    expect(isHighlighted(b(''))).toBe(false);
+  });
+});
+
+describe('extractTodoState', () => {
+  it('returns TODO for TODO blocks', () => {
+    expect(extractTodoState(b('TODO buy milk'))).toBe('TODO');
+  });
+
+  it('returns DONE for DONE blocks', () => {
+    expect(extractTodoState(b('DONE pay bills'))).toBe('DONE');
+  });
+
+  it('returns empty for plain blocks', () => {
+    expect(extractTodoState(b('plain text'))).toBe('');
+    expect(extractTodoState(b(''))).toBe('');
+    expect(extractTodoState(b('  TODO indented'))).toBe('');
+  });
+});
+
+describe('recursivelyCheckForRegexInBlock', () => {
+  it('matches a regex in the top-level block', () => {
+    expect(recursivelyCheckForRegexInBlock(b('TODO foo'), todoRegex)).toBe(true);
+  });
+
+  it('matches a regex in a child block', () => {
+    const tree = b('plain', [b('TODO child')]);
+    expect(recursivelyCheckForRegexInBlock(tree, todoRegex)).toBe(true);
+  });
+
+  it('matches a regex deep in the tree', () => {
+    const tree = b('plain', [b('also plain', [b('TODO grandchild')])]);
+    expect(recursivelyCheckForRegexInBlock(tree, todoRegex)).toBe(true);
+  });
+
+  it('returns false when no match anywhere', () => {
+    const tree = b('plain', [b('also plain', [b('still plain')])]);
+    expect(recursivelyCheckForRegexInBlock(tree, todoRegex)).toBe(false);
+  });
+
+  it('returns false on empty children', () => {
+    expect(recursivelyCheckForRegexInBlock(b('plain'), todoRegex)).toBe(false);
+  });
+
+  it('handles missing children field', () => {
+    expect(recursivelyCheckForRegexInBlock({ content: 'TODO x' }, todoRegex)).toBe(true);
+    expect(recursivelyCheckForRegexInBlock({ content: 'plain' }, todoRegex)).toBe(false);
+  });
+});
+
+describe('splitBlocksIntoGroups', () => {
+  it('returns single group for non-empty blocks', () => {
+    const blocks = [b('one'), b('two'), b('three')];
+    expect(splitBlocksIntoGroups(blocks)).toEqual([blocks]);
+  });
+
+  it('splits on empty separator', () => {
+    const blocks = [b('one'), b('two'), b(''), b('three')];
+    const groups = splitBlocksIntoGroups(blocks);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toEqual([b('one'), b('two')]);
+    expect(groups[1]).toEqual([b('three')]);
+  });
+
+  it('produces empty leading group on empty-first block', () => {
+    const blocks = [b(''), b('one')];
+    const groups = splitBlocksIntoGroups(blocks);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toEqual([]);
+    expect(groups[1]).toEqual([b('one')]);
+  });
+
+  it('produces consecutive empty groups for adjacent empties', () => {
+    const blocks = [b('a'), b(''), b(''), b('b')];
+    const groups = splitBlocksIntoGroups(blocks);
+    expect(groups).toHaveLength(3);
+    expect(groups[0]).toEqual([b('a')]);
+    expect(groups[1]).toEqual([]);
+    expect(groups[2]).toEqual([b('b')]);
+  });
+
+  it('handles empty input', () => {
+    expect(splitBlocksIntoGroups([])).toEqual([[]]);
+  });
+
+  it('preserves block identity (no copies)', () => {
+    const block1 = b('one');
+    const block2 = b('two');
+    const groups = splitBlocksIntoGroups([block1, block2]);
+    expect(groups[0][0]).toBe(block1);
+    expect(groups[0][1]).toBe(block2);
+  });
+});

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,77 @@
+// Pure helpers extracted from main.ts. Exported for unit tests.
+//
+// These functions operate on minimal block-shape interfaces so they
+// don't depend on @logseq/libs at runtime — pass any object with the
+// right shape and they work. main.ts uses them with full BlockEntity
+// instances at runtime.
+
+export const todoRegex = /^(TODO)\s+/;
+export const doneRegex = /^(DONE)\s+/;
+export const todoDoneRegex = /^(TODO|DONE)\s+/;
+export const isUnderlineRegex = /<ins>.*<\/ins>/;
+export const highlightRegex = /^(TODO\s+|DONE\s+|\s*)\^\^(.*)\^\^/;
+
+// Cycle TODO state: '' → 'TODO ' → 'DONE ' → ''.
+export const getNextTodoState = (todoState: string): string => {
+  return ({
+    'TODO': 'DONE ',
+    'DONE': '',
+    '': 'TODO ',
+  } as Record<string, string>)[todoState] ?? '';
+};
+
+// A minimal block shape that matches both legacy (`content`) and
+// modern (`title`) @logseq/libs BlockEntity. The helpers here only
+// touch the fields they need, so the lib stays free of SDK-version
+// concerns and main.ts can pass full BlockEntity instances through.
+export interface MinimalBlock {
+  content?: string;
+  title?: string;
+  children?: MinimalBlock[];
+}
+
+// Read a block's text content. In @logseq/libs >= 0.0.17 `block.content`
+// is @deprecated and `block.title` is canonical; both fields can be present
+// at runtime depending on Logseq version. Use this everywhere instead of
+// reading .content directly so the plugin works across SDK versions.
+export const blockContent = (block: MinimalBlock | undefined | null): string => {
+  if (!block) return '';
+  return block.title ?? block.content ?? '';
+};
+
+export const isHighlighted = (block: MinimalBlock): boolean => {
+  return highlightRegex.test(blockContent(block));
+};
+
+export const extractTodoState = (block: MinimalBlock): string => {
+  const match = todoDoneRegex.exec(blockContent(block));
+  return match !== null && match.length > 0 ? match[1] : '';
+};
+
+// Recursively check if any block in the subtree matches a regex.
+export function recursivelyCheckForRegexInBlock(
+  block: MinimalBlock,
+  regex: RegExp,
+): boolean {
+  if (regex.test(blockContent(block))) return true;
+  return (block.children ?? []).some(child =>
+    recursivelyCheckForRegexInBlock(child, regex),
+  );
+}
+
+// Split a flat list of blocks into groups separated by empty blocks.
+// Used by the journal-migration logic to identify "groups" of related
+// blocks that migrate together. An empty block at the head of the list
+// produces a leading empty group; consecutive empty blocks produce
+// consecutive empty groups.
+export function splitBlocksIntoGroups<B extends MinimalBlock>(blocks: B[]): B[][] {
+  const groups: B[][] = [[]];
+  for (const block of blocks) {
+    if (blockContent(block) !== '') {
+      groups[groups.length - 1].push(block);
+    } else {
+      groups.push([]);
+    }
+  }
+  return groups;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,16 +2,19 @@ import '@logseq/libs';
 
 import {BlockEntity} from '@logseq/libs/dist/LSPlugin';
 
-
-// Read a block's text content. In @logseq/libs >= 0.0.17 `block.content`
-// is @deprecated and `block.title` is canonical; both fields can be present
-// at runtime depending on Logseq version. Use this everywhere instead of
-// reading .content directly so the plugin works across SDK versions.
-const blockContent = (block: BlockEntity | undefined | null): string => {
-  if (!block) return '';
-  // .title is the new field but doesn't exist on the 0.0.9 type — cast.
-  return (block as any).title ?? block.content ?? '';
-};
+import {
+  blockContent,
+  doneRegex,
+  extractTodoState,
+  getNextTodoState,
+  highlightRegex,
+  isHighlighted,
+  isUnderlineRegex,
+  recursivelyCheckForRegexInBlock,
+  splitBlocksIntoGroups,
+  todoDoneRegex,
+  todoRegex,
+} from './lib';
 
 // Find the block immediately before `block` among its siblings. The legacy
 // API was `block.left.id`, but `BlockEntity.left` was removed in newer
@@ -44,13 +47,6 @@ async function getLeftSibling(block: BlockEntity): Promise<BlockEntity | null> {
   return await logseq.Editor.getBlock(siblings[idx - 1].uuid, { includeChildren: true });
 }
 
-const todoRegex = /^(TODO)\s+/;
-const doneRegex = /^(DONE)\s+/;
-const todoDoneRegex = /^(TODO|DONE)\s+/;
-const isUnderlineRegex = /<ins>.*<\/ins>/;
-
-const highlightRegex = /^(TODO\s+|DONE\s+|\s*)\^\^(.*)\^\^/;
-
 const settingsVersion = 'v1';
 export const defaultSettings = {
   keyBindings: {
@@ -75,14 +71,6 @@ const initSettings = () => {
   }
 };
 
-const getNextTodoState = (todoState: string) => {
-  return {
-    'TODO': 'DONE ',
-    'DONE': '',
-    '': 'TODO '
-  }[todoState];
-};
-
 const getSettings = (
   key: string | undefined,
   defaultValue: any = undefined
@@ -90,15 +78,6 @@ const getSettings = (
   let settings = logseq.settings;
   const merged = Object.assign(defaultSettings, settings);
   return key ? (merged[key] ? merged[key] : defaultValue) : merged;
-};
-
-const isHighlighted = (block: BlockEntity) => {
-  return highlightRegex.test(blockContent(block));
-};
-
-const extractTodoState = (block: BlockEntity) => {
-  let todoMatch = todoDoneRegex.exec(blockContent(block));
-  return (todoMatch !== null && todoMatch.length > 0) ? todoMatch[1] : '';
 };
 
 async function toggleHighlight() {
@@ -213,14 +192,7 @@ async function updateNewJournalWithAllTODOs({blocks, txData, txMeta}) {
   const latestJournalBlocks = await logseq.Editor.getPageBlocksTree(latestJournal.name);
   console.log({latestJournalBlocks});
 
-  let latestJournalBlockGroups = [[]];
-  for (let block of latestJournalBlocks) {
-    if (blockContent(block) !== '') {
-      latestJournalBlockGroups[latestJournalBlockGroups.length - 1].push(block);
-    } else {
-      latestJournalBlockGroups.push([]);
-    }
-  }
+  const latestJournalBlockGroups = splitBlocksIntoGroups(latestJournalBlocks);
   console.log({latestJournalBlockGroups});
 
   let newJournalLastBlock = await getLastBlock(newJournalBlock.name);
@@ -308,10 +280,6 @@ async function recursiveCopyBlocks(srcBlock: BlockEntity, lastDestBlock: BlockEn
   return [newBlock, isBlockRemoved, hasAnyDoneDescendant];
 }
 
-
-function recursivelyCheckForRegexInBlock(block: BlockEntity, regex: RegExp): boolean {
-  return regex.test(blockContent(block)) || block.children.some(child => recursivelyCheckForRegexInBlock(child as BlockEntity, regex));
-}
 
 export const getLastBlock = async function (
   pageName: string

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
Sets up the agent-runnable verification surface AND runs it in CI on every PR. Five new commands, two new gates, ~30 unit tests, plus a CI workflow.

```bash
pnpm test           # Vitest unit tests for pure helpers (<1s)
pnpm test:watch     # Vitest in watch mode
pnpm perf           # Headless perf gate via Playwright (~5s)
pnpm verify         # test + build + perf — the canonical agent gate
```

## CI
New `.github/workflows/ci.yml` runs on every PR (and push to master). Linux runner, ~30s wall-clock:
1. `pnpm install --frozen-lockfile`
2. `pnpm exec playwright install chromium` (needed by perf gate)
3. `pnpm test` — 29 unit tests
4. `pnpm build` — single-chunk output check
5. `pnpm perf` — `resourceCount === 1` + median < 800ms

(E2E runs in a separate workflow on macOS — see PR #19.)

## Code

### `src/lib.ts` + `src/lib.test.ts` (new)
Pure helpers extracted from `src/main.ts` and tested in isolation. 29 tests, all passing in 4ms:
- regex constants (todoRegex, doneRegex, todoDoneRegex, isUnderlineRegex, highlightRegex)
- `getNextTodoState`, `blockContent`, `isHighlighted`, `extractTodoState`
- `recursivelyCheckForRegexInBlock`, `splitBlocksIntoGroups`

`blockContent` reads `.title ?? .content ?? ''` so it works against both modern `@logseq/libs` (canonical `.title`) and the legacy `0.0.9` (`.content`).

### `src/main.ts` — uses lib.ts now (46 lines smaller)
Imports the helpers from `./lib` instead of carrying its own copies. The inlined group-split loop in `updateNewJournalWithAllTODOs` is replaced with a call to `splitBlocksIntoGroups`. The free-floating `recursivelyCheckForRegexInBlock` definition is removed (now imported). The plugin's runtime path is the same code as the unit-tested helpers — no drift.

### `scripts/perf.mjs` (new)
Headless Playwright driver of `perf-test/host.html`. Asserts:
1. `resourceCount === 1` — the 0.0.8 single-chunk invariant. Catches re-introduction of `manualChunks` automatically.
2. median load < 800ms over loopback. Generous threshold; the structural assertion is what really matters since loopback HTTP is faster than Logseq's `lsp://` Electron protocol handler.

## What's NOT in this PR

- **`pnpm check` (tsc --noEmit)** isn't in `verify` yet. The current tsconfig + strict mode produces ~20 errors against the existing code; that's tackled with the toolchain modernization (task #30 + #31).

## Test plan
- [x] `pnpm test` — 29 tests, 4ms.
- [x] `pnpm perf` — 1 resource, median 11ms, both invariants pass.
- [x] `pnpm verify` — green end-to-end locally.
- [x] `pnpm test:e2e` — **19/19 PASS** after the refactor (confirms extraction preserved behavior).
- [x] `pnpm build` still produces the expected single-chunk dist.
- [ ] CI workflow — first run will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)