### PR TITLE
test(e2e): retry trigger when Logseq doesn't recreate today

### DIFF
--- a/e2e/harness.mjs
+++ b/e2e/harness.mjs
@@ -207,12 +207,36 @@ class HarnessSession {
   // Trigger create-today-journal! by deleting today's file. If today doesn't
   // exist yet, write a placeholder first and wait long enough for Logseq's
   // fs-watcher to debounce.
+  //
+  // After deletion we poll for a few seconds for Logseq to recreate today
+  // (its create-today-journal! responds to the deletion). If the recreation
+  // doesn't happen within the poll window we explicitly re-write a placeholder
+  // and re-delete — sometimes the first deletion is coalesced into a no-op
+  // by Logseq's fs-watcher when datascript still has today's page from a
+  // recent prior reset.
   async triggerMigration() {
     if (!fs.existsSync(this.todayPath)) {
       fs.writeFileSync(this.todayPath, '-\n');
       await this.page.waitForTimeout(4000); // fs-watcher debounce; <4s is flaky
     }
     fs.unlinkSync(this.todayPath);
+    // Poll for up to 5s; if Logseq doesn't recreate today, retry the delete.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const start = Date.now();
+      while (Date.now() - start < 4000) {
+        if (fs.existsSync(this.todayPath)) return;
+        await this.page.waitForTimeout(200);
+      }
+      // Logseq didn't recreate. Re-seed + re-delete to force the trigger.
+      fs.writeFileSync(this.todayPath, '-\n');
+      await this.page.waitForTimeout(2500);
+      if (!fs.existsSync(this.todayPath)) {
+        // The placeholder we wrote got swallowed; bail and let the wait
+        // logic in waitForMigration handle the timeout.
+        return;
+      }
+      fs.unlinkSync(this.todayPath);
+    }
   }
 
   // Wait for Logseq to recreate today's file (signals migration completed).


### PR DESCRIPTION
## Summary
Fixes the occasional rule-5-empty-separator-cleanup flake in the full `pnpm test:e2e` run. ~50% failure rate before this PR; 5/5 green over 5 consecutive runs after.

## Root cause
`triggerMigration` deletes today's file expecting Logseq's `create-today-journal!` to fire. When today's page is still in datascript from a recent prior reset, Logseq's fs-watcher sometimes coalesces our delete with the prior state and skips the create-today response — today's file simply stays deleted and the migration never runs.

## Fix
After the initial delete, poll for up to 4s for Logseq to recreate today. If it doesn't, write a placeholder, wait for the fs-watcher debounce, then delete again. Up to 3 retry rounds (~12-15s worst case before falling through to the standard wait-for-migration timeout).

The happy path is unchanged: when Logseq recreates today within ~200ms (the common case), the poll exits immediately and the case proceeds at normal speed.

## Test plan
- [x] 5 consecutive full-suite runs all green: 19/19 PASS, 0 fails.
- [x] Quick test still passes (~17s).
- [x] Total full-suite runtime unchanged (~3m30s) on the happy path.

## Notes
- Closes task #38.
- Builds on the existing harness reliability work; the fix is additive and small (24 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)