### PR TITLE
ci: run pnpm test:e2e on every PR (macOS runner)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,96 @@
+name: E2E
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# Cancel duplicate runs on the same PR / branch
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    # macOS runner: lets the existing e2e/run.sh work as-is. The harness
+    # patches /tmp/LogseqPatched.app to honor LOGSEQ_FAKE_HOME (the
+    # macOS-specific HOME-vs-getpwuid workaround). Public repos get
+    # free macOS minutes; this job runs ~5 minutes.
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Enable corepack (pnpm)
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build plugin
+        run: pnpm build
+
+      # Logseq.app cache. The DMG is ~150MB; downloading every run is wasteful.
+      # Pin LOGSEQ_VERSION so cache misses only happen on intentional bumps.
+      - name: Cache Logseq.app
+        id: cache-logseq
+        uses: actions/cache@v4
+        with:
+          path: /Applications/Logseq.app
+          key: logseq-app-${{ env.LOGSEQ_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+        env:
+          LOGSEQ_VERSION: 0.10.15
+
+      - name: Download and install Logseq
+        if: steps.cache-logseq.outputs.cache-hit != 'true'
+        env:
+          LOGSEQ_VERSION: 0.10.15
+        run: |
+          set -euo pipefail
+          # GitHub macos-latest runners are arm64 as of 2026.
+          ARCH="$(uname -m)"
+          if [ "$ARCH" = "arm64" ]; then
+            DMG_NAME="Logseq-darwin-arm64-${LOGSEQ_VERSION}.dmg"
+          else
+            DMG_NAME="Logseq-darwin-x64-${LOGSEQ_VERSION}.dmg"
+          fi
+          URL="https://github.com/logseq/logseq/releases/download/${LOGSEQ_VERSION}/${DMG_NAME}"
+          echo "Downloading $URL"
+          curl -fL -o /tmp/Logseq.dmg "$URL"
+          # Mount, copy, eject
+          MOUNT_POINT=$(hdiutil attach -nobrowse -noverify -noautoopen /tmp/Logseq.dmg | tail -1 | awk '{print $3}')
+          echo "Mounted at $MOUNT_POINT"
+          cp -R "$MOUNT_POINT/Logseq.app" /Applications/
+          hdiutil detach "$MOUNT_POINT"
+          rm /tmp/Logseq.dmg
+          # Quarantine flag would prompt Gatekeeper on first launch; strip it
+          xattr -dr com.apple.quarantine /Applications/Logseq.app || true
+          ls /Applications/Logseq.app/Contents/MacOS/Logseq
+
+      - name: Install Playwright Chromium
+        # Needed by scripts/perf.mjs; the E2E suite uses Playwright's
+        # Electron driver against Logseq.app and doesn't need Chromium,
+        # but install it anyway so a future pnpm verify run works too.
+        run: pnpm exec playwright install chromium
+
+      - name: Run E2E suite
+        run: pnpm test:e2e
+        env:
+          # Disable color codes that break GitHub Actions log parsing
+          NO_COLOR: "1"
+
+      - name: Upload Logseq logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logseq-e2e-logs
+          path: |
+            /tmp/logseq-e2e-*
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,8 +27,13 @@ jobs:
         with:
           node-version: "20.x"
 
-      - name: Enable corepack (pnpm)
-        run: corepack enable
+      - name: Install pnpm
+        # Pin pnpm so CI doesn't drift to a major that requires a newer
+        # Node. Once the toolchain modernization (#30) lands, package.json
+        # will gain a "packageManager" field and we can switch to corepack.
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
Adds `.github/workflows/e2e.yml` that runs the existing `pnpm test:e2e` suite on every PR.

## What it does
1. Caches `/Applications/Logseq.app` keyed by `LOGSEQ_VERSION` (pinned to 0.10.15 — bump intentionally when targeting a new version).
2. On cache miss, downloads the Logseq DMG from `logseq/logseq` releases, mounts, copies, and strips the quarantine xattr.
3. Installs Playwright Chromium for `pnpm perf` (also useful for future `pnpm verify` runs).
4. Runs `pnpm test:e2e` — the full suite (~3m30s).
5. On failure, uploads `/tmp/logseq-e2e-*` dirs as artifacts (Logseq logs for debugging).

## Why macOS, not Linux
The existing `e2e/run.sh` patches `Logseq.app`'s `electron.js` to honor `LOGSEQ_FAKE_HOME` — a workaround for macOS's `HOME`-vs-`getpwuid` divergence. Linux Electron honors `HOME` so the patch isn't needed there, but porting to Linux would still need:
- AppImage extraction (no FUSE in GitHub runners)
- xvfb setup for headless display
- Linux-specific path handling in the harness

Sticking with macOS lets the existing harness Just Work. Public repos get unlimited macOS runner minutes per GitHub's pricing, so cost isn't a concern.

## Triggers
- `pull_request` (every PR)
- `push` to master (post-merge canary)
- `workflow_dispatch` (manual)

Concurrency group cancels in-progress runs when a PR is updated.

## What I can't easily verify locally
The workflow can only be tested by pushing the branch and watching the run. I've validated:
- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] Logseq 0.10.15 DMG URLs are correct (verified via GitHub API).
- [x] The harness works against a manually-installed Logseq.app on macOS — the only environmental gap from the runner is the DMG download/install step.

If the first run fails, the failure-mode artifact upload will give us logs to debug from. Plan: merge after one green run on this PR's own CI trigger.

## Notes
- This is the "CI for E2E" task (#36). Doesn't include `pnpm verify` in CI yet — that's task #35, blocked on #17 merging.
- `e2e/run.sh` works as-is; no harness changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)