### PR TITLE
docs: add workflow.md + refresh stale gotchas/release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist/
 
 .vscode/
 .DS_Store
+
+# Local-machine agent memory (per-developer notes that don't belong
+# in the repo — multi-account setup, machine-specific paths, etc.)
+CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ No UI, no network, no React. All logic lives in `src/main.ts`. The
 
 | What you're doing | Read this first |
 |---|---|
+| Onboarding to the inner-loop / branching / PR style | [`agents/workflow.md`](./agents/workflow.md) |
 | Touching `src/main.ts` for the first time | [`agents/overview.md`](./agents/overview.md) |
 | Running tests / writing tests | [`agents/testing.md`](./agents/testing.md) |
 | Anything that affects bundle/build/load time | [`agents/logseq-plugin-loading.md`](./agents/logseq-plugin-loading.md) and [`agents/perf-testing.md`](./agents/perf-testing.md) |

--- a/agents/README.md
+++ b/agents/README.md
@@ -12,14 +12,16 @@ and the constraints that should guide future changes.
 
 - [`overview.md`](./overview.md) — what this plugin does and how its
   pieces fit together.
-- [`testing.md`](./testing.md) — the headless E2E suite, dev loop
-  (`pnpm test:e2e:quick`), full suite (`pnpm test:e2e`), and how to
-  author new cases.
+- [`workflow.md`](./workflow.md) — branch naming, PR style, the inner
+  loop, CI shape, and other working-in-this-repo conventions.
+- [`testing.md`](./testing.md) — the unit + E2E test surface, what
+  each gate catches, and how to author new cases.
 - [`logseq-plugin-loading.md`](./logseq-plugin-loading.md) — how
   Logseq loads plugins, what the &quot;takes too long to load&quot; warning
   measures, and what *doesn't* count toward it.
 - [`build-and-release.md`](./build-and-release.md) — Vite config
-  rationale, the publish workflow, and version-bump checklist.
+  rationale, the tag-as-truth publish workflow, and the release
+  checklist.
 - [`perf-testing.md`](./perf-testing.md) — how to use the local perf
   harness and how to measure inside actual Logseq.
 - [`gotchas.md`](./gotchas.md) — non-obvious behaviors that surprised
@@ -30,7 +32,10 @@ and the constraints that should guide future changes.
 
 [`research/`](./research/) holds dated investigation logs, one file
 per topic. See [`research/README.md`](./research/README.md) for the
-convention. The active research doc is
-[`2026-05-09-modernization-ai-first-and-e2e.md`](./research/2026-05-09-modernization-ai-first-and-e2e.md);
-it covers what's shipped, what's queued, and the technical layer of
-the headless E2E PoC.
+convention. Two active research docs:
+
+- [`2026-05-09-modernization-ai-first-and-e2e.md`](./research/2026-05-09-modernization-ai-first-and-e2e.md)
+  — the technical layer of the headless E2E PoC, the modernization
+  plan, and AI-first repo conventions.
+- [`2026-05-10-logseq-sync-implications.md`](./research/2026-05-10-logseq-sync-implications.md)
+  — how Logseq Sync interacts with this plugin's `DB.onChanged` listener.

--- a/agents/build-and-release.md
+++ b/agents/build-and-release.md
@@ -60,18 +60,30 @@ them within an hour or so.
 
 ### Cutting a release
 
-1. Make sure master is in the state you want to release.
+1. Make sure master is in the state you want to release. Confirm CI
+   on master is green (`gh run list --branch master --limit 1`) — the
+   release workflow runs no tests of its own.
 2. `git tag <version>` (no `v` prefix — match the existing pattern,
    e.g. `0.0.9`).
 3. `git push origin <version>`.
 4. Watch the Action on GitHub. On success: the release page has the
    zip and tar.gz, and master gains a `chore: bump version to X.Y.Z`
    commit from `github-actions[bot]`.
+5. Pull the bump-back commit locally: `git pull --ff-only`. Otherwise
+   the next branch you cut from master will diverge by one.
 
 That's it. **You do not bump `package.json` manually.** The workflow
 makes the tag and `package.json` agree by construction, so the
 0.0.7-style drift (tag was 0.0.7, `package.json` said 0.0.6 for over
 a year) cannot recur.
+
+### Asset filenames in releases
+
+Releases publish `logseq-plugin-daily-todo.zip` and
+`logseq-plugin-daily-todo.tar.gz` (no version suffix in the filename).
+The Marketplace registry locates them by tag, not by filename. Older
+releases (≤ 0.0.8) had the version embedded in the filename; that's
+historical and doesn't break anything.
 
 ### Don't
 

--- a/agents/gotchas.md
+++ b/agents/gotchas.md
@@ -108,17 +108,24 @@ chunk count, presence of new requests, regression detection. For real
 absolute numbers, install the build into Logseq and use
 `__debugPluginsPerfInfo()`.
 
-## `@logseq/libs` v0.0.9 vs newer
+## `@logseq/libs` SDK versions
 
-This plugin pins `@logseq/libs@0.0.9`. v0.2/v0.3 changed enough APIs that
-upgrading isn't a drop-in — at minimum, sanity-check that `Editor`, `DB`,
-`App`, and `DB.onChanged` still match what `src/main.ts` uses. If you do
-upgrade, retest the journal-migration flow end-to-end against a real
-journal — the block-traversal API has been the most volatile area between
-versions.
+Currently pinned to `0.0.17` (the npm `latest` dist-tag and where the
+active-plugin tail sits as of 2026-05). `0.2.x` and `0.3.x` are tagged
+`next` — possible to bump but don't do so without a reason:
 
-The size delta is also against you: 0.3.3's `lsplugin.user.js` is ~103KB
-vs 0.0.9's ~75KB. Don't upgrade for perf reasons alone.
+- The bundle gets larger (0.3.3's `lsplugin.user.js` is ~103KB vs
+  0.0.17's ~80KB). Bigger bundle = more `lsp://` IPC overhead before
+  `logseq.ready()`.
+- API surface drift is small but nonzero. The cross-version helpers
+  in `src/lib.ts` (`blockContent` reading `.title ?? .content`,
+  `MinimalBlock.title?: unknown`) handle 0.0.x and 0.0.17+ already.
+  0.3.x might add new shapes that need the same treatment.
+
+The plugin's BlockEntity shape concerns are documented in
+[`src/lib.ts`](../src/lib.ts) and the cross-version research in
+[`research/2026-05-09-modernization-ai-first-and-e2e.md`](./research/2026-05-09-modernization-ai-first-and-e2e.md)
+§2.
 
 ## The plugin's keyboard shortcuts are global
 

--- a/agents/workflow.md
+++ b/agents/workflow.md
@@ -1,0 +1,123 @@
+# Working in this repo
+
+Patterns and conventions an agent (or human) should follow when making
+changes here. Most of this is implicit in the existing PRs but worth
+making explicit.
+
+## The standard inner loop
+
+For most changes:
+
+```bash
+# Iterate
+pnpm test:watch          # Vitest in watch mode if you're touching src/lib.ts
+pnpm test:e2e:quick      # ~17s sanity check after touching src/main.ts
+
+# Before committing
+pnpm verify              # check + lint + test + build + perf (~30s)
+pnpm test:e2e            # full E2E suite (~3m30s)
+
+# After committing
+git push -u origin <branch>
+gh pr create ...
+```
+
+`pnpm verify` is the canonical "did I break it" gate. If it's green
+locally, the corresponding CI jobs will be green too — they run the
+same commands on the same Node/pnpm versions.
+
+## Branch naming
+
+Used consistently across recent PRs:
+
+- `feat/<thing>` — adds a feature or capability (e.g. `feat/e2e-coverage`)
+- `fix/<thing>` — fixes a bug (e.g. `fix/rule-7-done-child-dropped`)
+- `chore/<thing>` — toolchain, deps, refactors with no user-visible change
+- `ci/<thing>` — workflow changes
+- `docs/<thing>` — documentation only
+
+Match the PR title's conventional-commit prefix to the branch prefix
+where reasonable.
+
+## Commit hygiene
+
+Each commit on a feature branch should leave the build green. Multi-step
+PRs (the toolchain modernization had 9 commits) are fine — but each step
+runs cleanly on its own.
+
+When a PR review surfaces a fix that belongs in an earlier commit,
+amend or rebase rather than tacking on at the end. Use
+`git push --force-with-lease` (not plain `--force`) so you don't
+clobber concurrent pushes.
+
+## PR descriptions
+
+Strong PR descriptions in this repo follow a small template:
+
+```
+## Summary
+<1-3 bullet points: what changed and why>
+
+## What's NOT in this PR
+<things deferred to a follow-up — name the task ID if it exists>
+
+## Test plan
+- [x] pnpm verify is green locally
+- [x] pnpm test:e2e is 19/19 PASS
+- [ ] Manual smoke test in Logseq with the unpacked dist
+```
+
+The "What's NOT in this PR" section is unusually valuable here because
+many of the recent changes were sequenced — knowing what a PR
+deliberately punts saves the reviewer asking.
+
+## CI is split across five gates (six with E2E)
+
+When you see a red dot on a PR, look at *which* job failed:
+
+| Job | What it catches | When to investigate first |
+|---|---|---|
+| `type-check` | `tsc --noEmit` | TS errors after a SDK bump or ts version change |
+| `lint` | ESLint (style + typescript-eslint recommended) | New code missed `--fix`, or a real correctness rule |
+| `unit` | Vitest on `src/lib.ts` | Pure logic regressions |
+| `sanity` | `pnpm build` | Build config broke |
+| `performance` | resourceCount === 1 + median load time | Someone re-added bundle splitting |
+| `e2e` | Logseq-driven journal migration + shortcuts | Real plugin behavior regressed |
+
+Each runs in its own job, in parallel. Failure in one doesn't kill the
+others. Concurrency group `ci-${{ workflow }}-${{ ref }}` cancels
+in-progress runs when a PR is force-pushed.
+
+The first five (Linux) take ~30s combined. E2E (macOS, runs Logseq.app)
+takes ~5 min. They share `pnpm install --frozen-lockfile` time.
+
+## Mass-formatting with eslint --fix
+
+When you do a refactor or migrate ESLint rules, run:
+
+```bash
+pnpm lint --fix
+```
+
+This auto-fixes mechanical issues across `src/`, `scripts/`, `e2e/`.
+Review the diff before committing — fixes are usually pure formatting
+but occasionally suggest deletions (unused vars).
+
+## What to read for what
+
+| If you're... | Start here |
+|---|---|
+| Onboarding | [`AGENTS.md`](../AGENTS.md), then [`overview.md`](./overview.md) |
+| Touching `src/main.ts` | [`overview.md`](./overview.md), [`gotchas.md`](./gotchas.md) |
+| Touching the bundle/build | [`logseq-plugin-loading.md`](./logseq-plugin-loading.md), [`gotchas.md`](./gotchas.md) |
+| Adding/modifying tests | [`testing.md`](./testing.md) |
+| Cutting a release | [`build-and-release.md`](./build-and-release.md) |
+| Investigating a past decision | [`research/`](./research/) |
+
+## Out-of-scope deliberately
+
+- **No UI**. The plugin doesn't render anything; don't add a settings panel.
+- **No network calls**. The plugin is offline-only.
+- **No DB-graph mode** support. The plugin runs against file-based graphs;
+  DB-graph behavior isn't tested. See research §2 for what would change.
+- **No CHANGELOG**. Releases use git history + the PR-description style above.


### PR DESCRIPTION
## Summary
After the toolchain modernization + 0.0.9 release, capture the working-in-this-repo conventions that were implicit across the recent PRs.

- New `agents/workflow.md` — the onboarding doc. Inner-loop commands, branch naming, commit hygiene, PR-description template, CI gate-by-gate debugging, the `eslint --fix` workflow, and a "what to read for what" index.
- `.gitignore` entry for `CLAUDE.local.md` — per-machine notes (multi-account `gh` setups, machine paths, etc.) that don't belong in the repo. Convention name; Claude Code auto-loads it as project-local memory if present.

## Doc refreshes
- `agents/gotchas.md` — drop the obsolete "@logseq/libs@0.0.9" advice; replace with current 0.0.17 + cross-version-helper context. (Pre-existing rule about not removing the unreachable `lastDestBlock.content !== ''` branch stays.)
- `agents/build-and-release.md` — document the 0.0.9+ asset filenames (no version suffix), add a "pull master after release" step so the bump-back commit doesn't surprise the next branch cut.
- `agents/README.md` — link `workflow.md` and the `2026-05-10-logseq-sync-implications.md` research doc.
- `AGENTS.md` — add an "onboarding" row to the where-to-look table pointing at `workflow.md`.

## Test plan
- [x] `pnpm verify` is green locally
- [x] All in-repo links from `AGENTS.md` and `agents/README.md` resolve
- No code change.

## What's NOT in this PR
- No actions/checkout, actions/setup-node, etc. version bump for the Node 24 deprecation. That's a separate workflow-only PR worth doing before June 2026.
- No CHANGELOG (deliberate — tracked in `agents/workflow.md` "Out of scope" — release flow is git history + PR descriptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)